### PR TITLE
Change "?? bytes" to "variable number of bytes"

### DIFF
--- a/memory.Rmd
+++ b/memory.Rmd
@@ -102,7 +102,7 @@ All vectors have three additional components: \indexc{SEXP}
   case, the true length represents the allocated space, and the length 
   represents the space currently used.
 
-* The data (?? bytes). An empty vector has 0 bytes of data. Numeric vectors occupy 8 bytes for
+* The data (variable number of bytes). An empty vector has 0 bytes of data. Numeric vectors occupy 8 bytes for
   every element, integer vectors 4, and complex vectors 16.
 
 If you're keeping count you'll notice that this only adds up to 36 bytes. The remaining 4 bytes are used for padding so that each component starts on an 8 byte (= 64-bit) boundary. Most cpu architectures require pointers to be aligned in this way, and even if they don't require it, accessing non-aligned pointers tends to be rather slow. (If you're interested, you can read more about it in [C structure packing](http://www.catb.org/esr/structure-packing/).)


### PR DESCRIPTION
I was confused when I read "?? bytes" because "??" is the result of a missing figure or reference in TeX. I changed it to "variable number".